### PR TITLE
Set `base` input to peter-evans/create-pull-request@v3.14.0

### DIFF
--- a/.github/workflows/imgcmp.yml
+++ b/.github/workflows/imgcmp.yml
@@ -1,5 +1,5 @@
 name: imgcmp
-on: push
+on: [push, pull_request]
 jobs:
   imgcmp:
     if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,8 @@ runs:
         else
           branch='${{ github.ref_name }}'
         fi
-        echo $branch
+        echo ::set-output name=base_branch::${branch}
+      id: branch
     - name: Git reset
       shell: bash
       run: |
@@ -144,7 +145,7 @@ runs:
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         branch: ${{ steps.commit.outputs.new_branch }}
-        base: ${{ github.head_ref }}
+        base: ${{ steps.branch.outputs.base_branch }}
         title: ${{ steps.template.outputs.title }}
         body: ${{ steps.template.outputs.message }}
         draft: false

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
     - name: Debug
       shell: bash
       run: |
-        echo ${{ toJSON(github) }}
+        echo '${{ toJSON(github) }}'
     - name: Create a pull request
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       uses: peter-evans/create-pull-request@v3.14.0

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Debug
       shell: bash
       run: |
-        echo '${{ toJSON(github) }}'
+        # echo '${{ toJSON(github) }}'
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
           branch=${{ github.head_ref }}
         else

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Git reset
       shell: bash
       run: |
-        git reset --hard origin/${{ github.head_ref }}
+        git reset --hard origin/${{ steps.actions-info.outputs.tag }}
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         jpegoptim --version
         optipng -v
         svgo -v
-    - name: Debug
+    - name: Branch information
       shell: bash
       run: |
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
@@ -47,7 +47,11 @@ runs:
       shell: bash
       run: |
         if [ '.' = $(basename ${{ github.action_path }}) ]; then
-          tag=${GITHUB_REF##*/}
+          if [ '${{ github.event_name }}' = 'pull_request' ]; then
+            tag='${{ steps.branch.outputs.base_branch }}'
+          else
+            tag=${GITHUB_REF##*/}
+          fi
         else
           tag=$(basename ${{ github.action_path }})
         fi
@@ -66,7 +70,7 @@ runs:
         deno run \
           --allow-read \
           --allow-write \
-          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/export_stat.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/export_stat.ts \
           '${{ inputs.paths-ignore-regexp }}' \
           '/tmp/imgcmp-stat.json'
     - name: Optimize images
@@ -76,7 +80,7 @@ runs:
         deno run \
           --allow-read \
           --allow-run \
-          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/optimize.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/optimize.ts \
           '${{ inputs.paths-ignore-regexp }}'
     - name: Export images' statistics in json after optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
@@ -85,7 +89,7 @@ runs:
         deno run \
           --allow-read \
           --allow-write \
-          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/export_stat.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/export_stat.ts \
           '${{ inputs.paths-ignore-regexp }}' \
           '/tmp/imgcmp-stat.json'
     - name: Export images' statistics in json after optimization
@@ -94,13 +98,13 @@ runs:
       run: |
         message=$(deno run \
           --allow-read \
-          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/show_stat_message.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/show_stat_message.ts \
           '/tmp/imgcmp-stat.json'
         )
 
         title=$(deno run \
           --allow-read \
-          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/show_stat_title.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/show_stat_title.ts \
           '/tmp/imgcmp-stat.json'
         )
 

--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,7 @@ runs:
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         branch: ${{ steps.commit.outputs.new_branch }}
+        base: ${{ github.head_ref }}
         title: ${{ steps.template.outputs.title }}
         body: ${{ steps.template.outputs.message }}
         draft: false

--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,11 @@ runs:
         echo ::set-output name=sha::${sha}
         echo ::set-output name=new_branch::${new_branch}
       id: commit
+    - name: Debug
+      shell: bash
+      run: |
+        echo ${{ toJSON(github) }}
+        echo ${{ toJSON(github.head_ref) }}
     - name: Create a pull request
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       uses: peter-evans/create-pull-request@v3.14.0

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,7 @@ runs:
         else
           tag=$(basename ${{ github.action_path }})
         fi
-
         echo ::set-output name=tag::${tag}
-        echo ::set-output name=base_branch::${GITHUB_REF##*/}
       id: actions-info
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
@@ -128,7 +126,6 @@ runs:
       shell: bash
       run: |
         echo ${{ toJSON(github) }}
-        echo ${{ toJSON(github.head_ref) }}
     - name: Create a pull request
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       uses: peter-evans/create-pull-request@v3.14.0
@@ -137,7 +134,6 @@ runs:
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         branch: ${{ steps.commit.outputs.new_branch }}
-        base: ${{ steps.actions-info.outputs.base_branch }}
         title: ${{ steps.template.outputs.title }}
         body: ${{ steps.template.outputs.message }}
         draft: false

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,12 @@ runs:
       shell: bash
       run: |
         echo '${{ toJSON(github) }}'
+        if [ '${{ github.event_name }}' = 'pull_request' ]; then
+          branch='${{ github.ref_name }}'
+        else
+          branch='${{ github.head_ref }}'
+        fi
+        echo $branch
     - name: Git reset
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -46,16 +46,15 @@ runs:
       run: |
         echo '${{ toJSON(github) }}'
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
-          branch='${{ github.head_ref }}'
+          branch=${{ github.head_ref }}
         else
-          branch='${{ github.ref_name }}'
+          branch=${{ github.ref_name }}
         fi
         echo ::set-output name=base_branch::${branch}
       id: branch
     - name: Git reset
       shell: bash
       run: |
-        git fetch
         git log --oneline -20
         git reset --hard origin/${{ steps.branch.outputs.base_branch }}
     - name: Export images' statistics in json before optimization

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,9 @@ runs:
         else
           tag=$(basename ${{ github.action_path }})
         fi
+
         echo ::set-output name=tag::${tag}
+        echo ::set-output name=base_branch::${GITHUB_REF##*/}
       id: actions-info
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
@@ -130,6 +132,7 @@ runs:
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         branch: ${{ steps.commit.outputs.new_branch }}
+        base: ${{ steps.actions-info.outputs.base_branch }}
         title: ${{ steps.template.outputs.title }}
         body: ${{ steps.template.outputs.message }}
         draft: false

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ runs:
         fi
         echo ::set-output name=tag::${tag}
       id: actions-info
+    - name: Git reset
+      shell: bash
+      run: |
+        git reset --hard origin/${{ github.head_ref }}
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,18 +29,6 @@ runs:
         jpegoptim --version
         optipng -v
         svgo -v
-    - uses: actions/checkout@v2
-      if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
-    - name: Get actions information
-      shell: bash
-      run: |
-        if [ '.' = $(basename ${{ github.action_path }}) ]; then
-          tag=${GITHUB_REF##*/}
-        else
-          tag=$(basename ${{ github.action_path }})
-        fi
-        echo ::set-output name=tag::${tag}
-      id: actions-info
     - name: Debug
       shell: bash
       run: |
@@ -51,6 +39,20 @@ runs:
         fi
         echo ::set-output name=base_branch::${branch}
       id: branch
+    - uses: actions/checkout@v3
+      if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
+      with:
+        ref: ${{ steps.branch.outputs.base_branch }}
+    - name: Get actions information
+      shell: bash
+      run: |
+        if [ '.' = $(basename ${{ github.action_path }}) ]; then
+          tag=${GITHUB_REF##*/}
+        else
+          tag=$(basename ${{ github.action_path }})
+        fi
+        echo ::set-output name=tag::${tag}
+      id: actions-info
     - name: Git reset
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         deno run \
           --allow-read \
           --allow-write \
-          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/export_stat.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/export_stat.ts \
           '${{ inputs.paths-ignore-regexp }}' \
           '/tmp/imgcmp-stat.json'
     - name: Optimize images
@@ -74,7 +74,7 @@ runs:
         deno run \
           --allow-read \
           --allow-run \
-          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/optimize.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/optimize.ts \
           '${{ inputs.paths-ignore-regexp }}'
     - name: Export images' statistics in json after optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
@@ -83,7 +83,7 @@ runs:
         deno run \
           --allow-read \
           --allow-write \
-          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/export_stat.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/export_stat.ts \
           '${{ inputs.paths-ignore-regexp }}' \
           '/tmp/imgcmp-stat.json'
     - name: Export images' statistics in json after optimization
@@ -92,13 +92,13 @@ runs:
       run: |
         message=$(deno run \
           --allow-read \
-          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/show_stat_message.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/show_stat_message.ts \
           '/tmp/imgcmp-stat.json'
         )
 
         title=$(deno run \
           --allow-read \
-          https://raw.githubusercontent.com/9sako6/imgcmp/${{ steps.actions-info.outputs.tag }}/src/show_stat_title.ts \
+          https://raw.githubusercontent.com/9sako6/imgcmp/master/src/show_stat_title.ts \
           '/tmp/imgcmp-stat.json'
         )
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         jpegoptim --version
         optipng -v
         svgo -v
-    - uses: actions/checkout@v3.0.0
+    - uses: actions/checkout@v2
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
     - name: Get actions information
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,8 @@ runs:
     - name: Git reset
       shell: bash
       run: |
-        git log --oneline -20
+        # NOTE: If the trigger event is 'pull_request', `git fetch` is necessary.
+        git fetch
         git reset --hard origin/${{ steps.branch.outputs.base_branch }}
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}

--- a/action.yml
+++ b/action.yml
@@ -46,9 +46,9 @@ runs:
       run: |
         echo '${{ toJSON(github) }}'
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
-          branch='${{ github.ref_name }}'
-        else
           branch='${{ github.head_ref }}'
+        else
+          branch='${{ github.ref_name }}'
         fi
         echo $branch
     - name: Git reset

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ runs:
         fi
         echo ::set-output name=tag::${tag}
       id: actions-info
+    - name: Debug
+      shell: bash
+      run: |
+        echo '${{ toJSON(github) }}'
     - name: Git reset
       shell: bash
       run: |
@@ -126,10 +130,6 @@ runs:
         echo ::set-output name=sha::${sha}
         echo ::set-output name=new_branch::${new_branch}
       id: commit
-    - name: Debug
-      shell: bash
-      run: |
-        echo '${{ toJSON(github) }}'
     - name: Create a pull request
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       uses: peter-evans/create-pull-request@v3.14.0

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,9 @@ runs:
     - name: Git reset
       shell: bash
       run: |
-        git reset --hard origin/${{ steps.actions-info.outputs.tag }}
+        git fetch
+        git log --oneline -20
+        git reset --hard origin/${{ steps.branch.outputs.base_branch }}
     - name: Export images' statistics in json before optimization
       if: ${{ startsWith(github.head_ref, 'actions/imgcmp/') != true }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,6 @@ runs:
     - name: Debug
       shell: bash
       run: |
-        # echo '${{ toJSON(github) }}'
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
           branch=${{ github.head_ref }}
         else


### PR DESCRIPTION
Fix the following error.
When actions is triggered by pull_request, this occures.

```bash
Error: When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.
```